### PR TITLE
Fix User-Agent per RFC7231

### DIFF
--- a/lib/nerves_hub_link_common/downloader.ex
+++ b/lib/nerves_hub_link_common/downloader.ex
@@ -354,5 +354,5 @@ defmodule NervesHubLinkCommon.Downloader do
     do: [{"X-Retry-Number", "#{retry_number}"} | headers]
 
   defp add_user_agent_header(headers, _),
-    do: [{"User-Agent", "Nerves HTTP Client 0.1.0"} | headers]
+    do: [{"User-Agent", "NHL/#{Application.spec(:nerves_hub_link_common)[:vsn]}"} | headers]
 end


### PR DESCRIPTION
The User-Agent field has a particular expected format and the current
setting doesn't follow it. This commit fixes it and provides the
Nerves Hub Link (NHL) version - actually this library's version.
Assuming that there is any reason to debug HTTP downloads based on this
field, that seems like the most reasonable thing to check.