### PR TITLE
Implement a new param worst_case_download_speed

### DIFF
--- a/lib/nerves_hub_link_common/downloader.ex
+++ b/lib/nerves_hub_link_common/downloader.ex
@@ -18,7 +18,7 @@ defmodule NervesHubLinkCommon.Downloader do
   require Logger
   use GenServer
 
-  alias NervesHubLinkCommon.{Downloader, Downloader.RetryConfig}
+  alias NervesHubLinkCommon.{Downloader, Downloader.RetryConfig, Downloader.TimeoutCalculation}
 
   defstruct uri: nil,
             conn: nil,
@@ -31,11 +31,16 @@ defmodule NervesHubLinkCommon.Downloader do
             handler_fun: nil,
             retry_args: nil,
             max_timeout: nil,
-            retry_timeout: nil
+            retry_timeout: nil,
+            worst_case_timeout: nil,
+            worst_case_timeout_remaining_ms: nil
 
   @type handler_event :: {:data, binary()} | {:error, any()} | :complete
   @type event_handler_fun :: (handler_event -> any())
   @type retry_args :: RetryConfig.t()
+
+  # alias for readability
+  @typep timer() :: reference()
 
   @type t :: %Downloader{
           uri: nil | URI.t(),
@@ -48,8 +53,10 @@ defmodule NervesHubLinkCommon.Downloader do
           retry_number: non_neg_integer(),
           handler_fun: event_handler_fun,
           retry_args: retry_args(),
-          max_timeout: reference(),
-          retry_timeout: nil | reference()
+          max_timeout: timer(),
+          retry_timeout: nil | timer(),
+          worst_case_timeout: nil | timer(),
+          worst_case_timeout_remaining_ms: nil | non_neg_integer()
         }
 
   @type initialized_download :: %Downloader{
@@ -117,6 +124,11 @@ defmodule NervesHubLinkCommon.Downloader do
     {:stop, :max_timeout_reached, state}
   end
 
+  # this message is scheduled when we receive the `content_length` value
+  def handle_info(:worst_case_download_speed_timeout, %Downloader{} = state) do
+    {:stop, :worst_case_download_speed_reached, state}
+  end
+
   # this message is delivered after `state.retry_args.idle_timeout`
   # milliseconds have occurred. It indicates that many milliseconds have elapsed since
   # the last "chunk" from the HTTP server
@@ -154,7 +166,6 @@ defmodule NervesHubLinkCommon.Downloader do
       {:ok, conn, responses} ->
         handle_responses(responses, %{state | conn: conn})
 
-      # i think there's probably a race condition here...
       {:error, conn, error, responses} ->
         _ = handler.({:error, error})
         handle_responses(responses, reschedule_resume(%{state | conn: conn}))
@@ -167,8 +178,38 @@ defmodule NervesHubLinkCommon.Downloader do
   # schedules a message to be delivered based on retry args
   @spec reschedule_resume(t()) :: resume_rescheduled()
   defp reschedule_resume(%Downloader{retry_number: retry_number} = state) do
+    # cancel the worst_case_timeout if it was running
+    worst_case_timeout_remaining_ms =
+      if state.worst_case_timeout do
+        Process.cancel_timer(state.worst_case_timeout) || nil
+      end
+
     timer = Process.send_after(self(), :resume, state.retry_args.time_between_retries)
-    %Downloader{state | retry_timeout: timer, retry_number: retry_number + 1}
+
+    %Downloader{
+      state
+      | retry_timeout: timer,
+        retry_number: retry_number + 1,
+        worst_case_timeout_remaining_ms: worst_case_timeout_remaining_ms
+    }
+  end
+
+  @spec schedule_worst_case_timer(t()) :: t()
+  # only calculate worst_case_timeout_remaining_ms is not set
+  defp schedule_worst_case_timer(%Downloader{worst_case_timeout_remaining_ms: nil} = downloader) do
+    # decompose here because in the formatter doesn't like all this being in the head
+    %Downloader{retry_args: retry_config, content_length: content_length} = downloader
+    %RetryConfig{worst_case_download_speed: speed} = retry_config
+    ms = TimeoutCalculation.calculate_worst_case_timeout(content_length, speed)
+    timer = Process.send_after(self(), :worst_case_download_speed_timeout, ms)
+    %Downloader{downloader | worst_case_timeout: timer}
+  end
+
+  # worst_case_timeout_remaining_ms gets set if the timer gets canceled by reschedule_resume/1
+  # this is done so that the timer doesn't keep counting while not actively downloading data
+  defp schedule_worst_case_timer(%Downloader{worst_case_timeout_remaining_ms: ms} = downloader) do
+    timer = Process.send_after(self(), :worst_case_download_speed_timeout, ms)
+    %Downloader{downloader | worst_case_timeout: timer}
   end
 
   defp handle_responses([response | rest], %Downloader{} = state) do
@@ -250,7 +291,7 @@ defmodule NervesHubLinkCommon.Downloader do
         %Downloader{request_ref: request_ref, content_length: content_length} = state
       )
       when content_length > 0 do
-    %Downloader{state | response_headers: headers}
+    schedule_worst_case_timer(%Downloader{state | response_headers: headers})
   end
 
   def handle_response(
@@ -265,7 +306,13 @@ defmodule NervesHubLinkCommon.Downloader do
         :ok
     end
 
-    %Downloader{state | response_headers: headers, content_length: fetch_content_length(headers)}
+    content_length = fetch_content_length(headers)
+
+    schedule_worst_case_timer(%Downloader{
+      state
+      | response_headers: headers,
+        content_length: content_length
+    })
   end
 
   def handle_response(

--- a/lib/nerves_hub_link_common/downloader/retry_config.ex
+++ b/lib/nerves_hub_link_common/downloader/retry_config.ex
@@ -15,16 +15,55 @@ defmodule NervesHubLinkCommon.Downloader.RetryConfig do
     # if the total time since this server has started reaches this time,
     # stop trying, give up, disconnect, etc
     # started right when the gen_server starts
-    max_timeout: 3_600_000,
+    # default is 24 hours as that is how long NervesHub AWS urls are signed for
+    max_timeout: 86_400_000,
 
     # don't bother retrying until this time has passed
-    time_between_retries: 15_000
+    time_between_retries: 15_000,
+
+    # worst case average download speed in bits/second
+    # This is used to calculate a "sensible" timeout that is shorter than `max_timeout`.
+    # LTE Cat M1 modems sometimes top out at 32 kbps (30 kbps for some slack)
+    worst_case_download_speed: 30_000
   ]
 
+  @typedoc """
+  maximum number of disconnects. After this limit is reached
+  the download will be stopped and will no longer be retried
+  """
+  @type max_disconnects :: non_neg_integer()
+
+  @typedoc """
+  time in milliseconds between chunks of data received
+  that once elapsed will trigger a retry. This event counts
+  towards the `max_disconnects` counter
+  """
+  @type idle_timeout :: non_neg_integer()
+
+  @typedoc """
+  maximum time in milliseconds that a download can exist for.
+  after this amount of time has elapsed, the download is canceled
+  and the download process will crash
+  """
+  @type max_timeout :: non_neg_integer()
+
+  @typedoc """
+  time in milliseconds to wait before attempting to retry a download
+  """
+  @type time_between_retries :: non_neg_integer()
+
+  @typedoc """
+  worst case download speed specified in bytes per second. This is
+  used to calculate the "worst case" download timeout. it is meant to
+  fail faster than waiting for `max_timeout` to elapse
+  """
+  @type worst_case_download_speed :: non_neg_integer()
+
   @type t :: %__MODULE__{
-          max_disconnects: non_neg_integer(),
-          idle_timeout: timeout(),
-          max_timeout: timeout(),
-          time_between_retries: non_neg_integer()
+          max_disconnects: max_disconnects(),
+          idle_timeout: idle_timeout(),
+          max_timeout: max_timeout(),
+          time_between_retries: time_between_retries(),
+          worst_case_download_speed: worst_case_download_speed()
         }
 end

--- a/lib/nerves_hub_link_common/downloader/timeout_calculation.ex
+++ b/lib/nerves_hub_link_common/downloader/timeout_calculation.ex
@@ -1,0 +1,16 @@
+defmodule NervesHubLinkCommon.Downloader.TimeoutCalculation do
+  @moduledoc """
+  Pure functions for dealing with timeouts
+  """
+
+  @type number_of_bytes :: non_neg_integer()
+  @type bits_per_second :: non_neg_integer()
+
+  @doc "Calculates the worst_case_timeout value based on content_length header and worst case network speed"
+  @spec calculate_worst_case_timeout(number_of_bytes, bits_per_second) :: non_neg_integer()
+  def calculate_worst_case_timeout(content_length, speed) do
+    # need to extract milliseconds based on a speed in seconds and number of bits
+    # set a max of 1 minute in case the data is smaller than the conceivably fastest speed
+    round(content_length * 8 / speed * 1000) |> max(60_000)
+  end
+end

--- a/test/nerves_hub_link_common/downloader/timeout_calculation_test.exs
+++ b/test/nerves_hub_link_common/downloader/timeout_calculation_test.exs
@@ -1,0 +1,15 @@
+defmodule NervesHubLinkCommon.Downloader.TimeoutCalculationTest do
+  use ExUnit.Case
+  alias NervesHubLinkCommon.Downloader.TimeoutCalculation
+
+  test "calculate_worst_case_timeout" do
+    # 20 mb @ 30 b/sec is about 1.5 hours
+    assert TimeoutCalculation.calculate_worst_case_timeout(20_971_520, 30_000) == 5_592_405
+  end
+
+  test "calculate_worst_case_timeout minimum value" do
+    # small data now matter how slow finishes quickly
+    # ensure there's a minimum timeout of 60000 ms
+    assert TimeoutCalculation.calculate_worst_case_timeout(1, 30_000) == 60000
+  end
+end

--- a/test/nerves_hub_link_common/downloader_test.exs
+++ b/test/nerves_hub_link_common/downloader_test.exs
@@ -15,7 +15,8 @@ defmodule NervesHubLinkCommon.DownloaderTest do
     max_disconnects: 10,
     idle_timeout: 60_000,
     max_timeout: 3_600_000,
-    time_between_retries: 10
+    time_between_retries: 10,
+    worst_case_download_speed: 30_000
   }
 
   @failure_url "http://localhost/this_should_fail"


### PR DESCRIPTION
This allows a "helper" timeout to be set which allows the
Downloader process to "fail fast", preventing the need to wait
for the full `max_timeout` timeout to be reached