### PR TITLE
Release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.1.3
+
+* New features
+  * New `RetryConfig` param: `worst_case_download_speed`. This makes it
+    possible to match the timeout to the download size and fail before `max_timeout`.
+  * `max_timeout` is now 24 hours to match the NervesHub download URL validity time.
+    Now downloads can survive multi-hour network outages without starting over.
+
 ## v0.1.2
 
 * Bug Fixes

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule NervesHubLinkCommon.MixProject do
   use Mix.Project
 
-  @version "0.1.2"
+  @version "0.1.3"
   @source_url "https://github.com/nerves-hub/nerves_hub_link_common"
 
   def project do


### PR DESCRIPTION
## v0.1.3

* New features
  * New `RetryConfig` param: `worst_case_download_speed`. This makes it
    possible to "fail fast" instead of having to wait for the `max_timeout`
    timeout to be reached