### PR TITLE
skip attempting a download if update_available: false in update payload

### DIFF
--- a/lib/nerves_hub_link_common/update_manager.ex
+++ b/lib/nerves_hub_link_common/update_manager.ex
@@ -148,6 +148,11 @@ defmodule NervesHubLinkCommon.UpdateManager do
 
   @spec maybe_update_firmware(map(), State.t()) ::
           State.download_started() | State.download_rescheduled() | State.t()
+  defp maybe_update_firmware(%{update_available: false}, %State{} = state) do
+    # if the `update_available` key is false, bail early. There is no update
+    state
+  end
+
   defp maybe_update_firmware(_data, %State{status: {:updating, _percent}} = state) do
     # Received an update message from NervesHub, but we're already in progress.
     # It could be because the deployment/device was edited making a duplicate


### PR DESCRIPTION
adds a noop clause when `update_available: false`. Relevant changes to nerves_hub_web:
   * https://github.com/nerves-hub/nerves_hub_web/pull/732
   * https://github.com/nerves-hub/nerves_hub_web/pull/734
   * https://github.com/nerves-hub/nerves_hub_web/pull/739
