### PR TITLE
send firmware UUID with handle_fwup_message/2

### DIFF
--- a/lib/nerves_hub_link_common/fwup_config.ex
+++ b/lib/nerves_hub_link_common/fwup_config.ex
@@ -59,7 +59,7 @@ defmodule NervesHubLinkCommon.FwupConfig do
     do: raise(ArgumentError, message: "invalid arg: fwup_devpath")
 
   defp validate_handle_fwup_message!(%__MODULE__{handle_fwup_message: handle_fwup_message} = args)
-       when is_function(handle_fwup_message, 1),
+       when is_function(handle_fwup_message, 2),
        do: args
 
   defp validate_handle_fwup_message!(%__MODULE__{}),

--- a/test/nerves_hub_link_common/update_manager_test.exs
+++ b/test/nerves_hub_link_common/update_manager_test.exs
@@ -26,7 +26,7 @@ defmodule NervesHubLinkCommon.UpdateManagerTest do
 
     test "apply", %{update_payload: update_payload, devpath: devpath} do
       test_pid = self()
-      fwup_fun = &send(test_pid, {:fwup, &1})
+      fwup_fun = &send(test_pid, {:fwup, &1, &2})
       update_available_fun = fn _ -> :apply end
 
       fwup_config = %FwupConfig{
@@ -38,14 +38,16 @@ defmodule NervesHubLinkCommon.UpdateManagerTest do
       {:ok, manager} = UpdateManager.start_link(fwup_config)
       assert UpdateManager.apply_update(manager, update_payload) == {:updating, 0}
 
-      assert_receive {:fwup, {:progress, 0}}
-      assert_receive {:fwup, {:progress, 100}}
-      assert_receive {:fwup, {:ok, 0, ""}}
+      meta = update_payload.firmware_meta
+
+      assert_receive {:fwup, {:progress, 0}, ^meta}
+      assert_receive {:fwup, {:progress, 100}, ^meta}
+      assert_receive {:fwup, {:ok, 0, ""}, ^meta}
     end
 
     test "reschedule", %{update_payload: update_payload, devpath: devpath} do
       test_pid = self()
-      fwup_fun = &send(test_pid, {:fwup, &1})
+      fwup_fun = &send(test_pid, {:fwup, &1, &2})
 
       update_available_fun = fn _ ->
         case Process.get(:reschedule) do
@@ -70,9 +72,11 @@ defmodule NervesHubLinkCommon.UpdateManagerTest do
       assert_received :rescheduled
       refute_received {:fwup, _}
 
-      assert_receive {:fwup, {:progress, 0}}
-      assert_receive {:fwup, {:progress, 100}}
-      assert_receive {:fwup, {:ok, 0, ""}}
+      meta = update_payload.firmware_meta
+
+      assert_receive {:fwup, {:progress, 0}, ^meta}
+      assert_receive {:fwup, {:progress, 100}, ^meta}
+      assert_receive {:fwup, {:ok, 0, ""}, ^meta}
     end
   end
 end


### PR DESCRIPTION
For https://github.com/nerves-hub/nerves_hub_link/pull/69 to aid in sending the UUID to the web on progress updates