### PR TITLE
Support OTP 25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ install_system_deps: &install_system_deps
         apk add fwup --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 
 jobs:
-  build_elixir_1_13_otp_24:
+  build_elixir_1_13_otp_25:
     docker:
-      - image: hexpm/elixir:1.13.4-erlang-24.3.3-alpine-3.15.3
+      - image: hexpm/elixir:1.13.4-erlang-25.0-alpine-3.15.4
     <<: *defaults
     steps:
       - checkout
@@ -45,9 +45,20 @@ jobs:
             - _build
             - deps
 
+  build_elixir_1_13_otp_24:
+    docker:
+      - image: hexpm/elixir:1.13.4-erlang-24.3.4-alpine-3.15.3
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_hex_rebar
+      - <<: *install_system_deps
+      - run: mix deps.get
+      - run: mix test
+
   build_elixir_1_12_otp_24:
     docker:
-      - image: hexpm/elixir:1.12.3-erlang-24.1.1-alpine-3.14.0
+      - image: hexpm/elixir:1.12.3-erlang-24.3.4-alpine-3.15.3
     <<: *defaults
     steps:
       - checkout
@@ -58,7 +69,7 @@ jobs:
 
   build_elixir_1_11_otp_23:
     docker:
-      - image: hexpm/elixir:1.11.4-erlang-23.3.4-alpine-3.13.3
+      - image: hexpm/elixir:1.11.4-erlang-23.3.4.13-alpine-3.15.3
     <<: *defaults
     steps:
       - checkout
@@ -71,6 +82,7 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_13_otp_25
       - build_elixir_1_13_otp_24
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23

--- a/lib/nerves_hub_link_common/downloader.ex
+++ b/lib/nerves_hub_link_common/downloader.ex
@@ -350,7 +350,9 @@ defmodule NervesHubLinkCommon.Downloader do
   end
 
   @spec resume_download(URI.t(), t()) ::
-          {:ok, initialized_download()} | {:error, Mint.Types.error()}
+          {:ok, initialized_download()}
+          | {:error, Mint.Types.error()}
+          | {:error, Mint.HTTP.t(), Mint.Types.error()}
   defp resume_download(
          %URI{scheme: scheme, host: host, port: port, path: path, query: query} = uri,
          %Downloader{} = state

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule NervesHubLinkCommon.MixProject do
 
   defp dialyzer() do
     [
-      flags: [:race_conditions, :error_handling, :underspecs, :unmatched_returns],
+      flags: [:missing_return, :extra_return, :error_handling, :underspecs, :unmatched_returns],
       plt_add_apps: [],
       list_unused_filters: true
     ]


### PR DESCRIPTION
* remove deprecated `:race_conditions` dialyzer option
* Add new `:missing_return` and `:extra_return` dialyzer options
* Update Elixir/Erlang CI versions