### PR TITLE
Allow custom retry config

### DIFF
--- a/lib/nerves_hub_link_common/downloader.ex
+++ b/lib/nerves_hub_link_common/downloader.ex
@@ -93,7 +93,10 @@ defmodule NervesHubLinkCommon.Downloader do
   """
   @spec start_download(String.t() | URI.t(), event_handler_fun()) :: GenServer.on_start()
   def start_download(url, fun) when is_function(fun, 1) do
-    GenServer.start_link(__MODULE__, [URI.parse(url), fun, %RetryConfig{}])
+    retry_config =
+      struct(RetryConfig, Application.get_env(:nerves_hub_link_common, :retry_config, []))
+
+    GenServer.start_link(__MODULE__, [URI.parse(url), fun, retry_config])
   end
 
   @spec start_download(String.t() | URI.t(), event_handler_fun(), RetryConfig.t()) ::


### PR DESCRIPTION
When starting downloader without RetryConfig argument, retry config is built by merging `:retry_config` application env with defaults.

For instance, default `max_disconnects` could be overriden with:
```
config :nerves_hub_link_common, :retry_config, max_disconnects: 20
```

Closes #32